### PR TITLE
Cleaned up some code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["bacit-dotnet.MVC", "bacit-dotnet.MVC/"]
 RUN ls /src
-WORKDIR "/src/bacit-dotnet.MVC/"
-RUN ls "/src/bacit-dotnet.MVC/"
+WORKDIR /src/bacit-dotnet.MVC/
+RUN ls /src/bacit-dotnet.MVC/
 
 RUN dotnet restore 
 RUN dotnet build -c Release  --no-restore

--- a/startDb.cmd
+++ b/startDb.cmd
@@ -1,1 +1,7 @@
-docker run --rm --env "TZ=Europe/Oslo" --name mariadb -p 3308:3306/tcp -v "%cd%\database":/var/lib/mysql -e MYSQL_ROOT_PASSWORD=12345 -d mariadb:10.5.11
+docker run --rm ^
+  --env "TZ=Europe/Oslo" ^
+  --name mariadb ^
+  --publish 3308:3306/tcp ^
+  --volume "%cd%\database":/var/lib/mysql ^
+  --env MYSQL_ROOT_PASSWORD=12345 ^
+  --detach mariadb:10.5.11

--- a/startDb.sh
+++ b/startDb.sh
@@ -1,1 +1,7 @@
-docker run --rm --env "TZ=Europe/Oslo" --name mariadb -p 3308:3306/tcp -v "$(pwd)/database":/var/lib/mysql -e MYSQL_ROOT_PASSWORD=12345 -d mariadb:10.5.11
+docker run --rm \
+    --env "TZ=Europe/Oslo" \
+    --name mariadb \
+    --publish 3308:3306/tcp \
+    --volume "$(pwd)/database":/var/lib/mysql \
+    --env MYSQL_ROOT_PASSWORD=12345 \
+    --detach mariadb:10.5.11


### PR DESCRIPTION
Cleaned up the code for `startDb.cmd` and `startDb.sh` to make it easier for new beginners to understand what `docker` command actually does.

The double quotes around the path names in the `Dockerfile` was also removed as its not needed. Its only needed when the path name in an array